### PR TITLE
Point the control file's homepage to the new one

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends:
  libxinerama-dev, libxss-dev, libxtst-dev, dh-autoreconf, dh-systemd,
  libmspack-dev, libssl1.0-dev, libxerces-c-dev, libxml-security-c-dev
 Standards-Version: 3.9.6
-Homepage: http://open-vm-tools.sourceforge.net/
+Homepage: https://github.com/vmware/open-vm-tools
 Vcs-Git: https://github.com/bzed/pkg-open-vm-tools.git
 Vcs-Browser: https://github.com/bzed/pkg-open-vm-tools
 


### PR DESCRIPTION
The upstream open-vm-tools switched from sourceforge to github. This
simply updates the link to reflect that.

Signed-off-by: Chris Glass <chris.glass@canonical.com>