### PR TITLE
Fix scsi timeout setting error on debian stretch

### DIFF
--- a/debian/patches/debian/scsi-udev-rule
+++ b/debian/patches/debian/scsi-udev-rule
@@ -1,0 +1,8 @@
+--- a/open-vm-tools/udev/99-vmware-scsi-udev.rules
++++ b/open-vm-tools/udev/99-vmware-scsi-udev.rules
+@@ -1,3 +1,2 @@
+-ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*" , ATTRS{model}=="Virtual disk*", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'"
+-ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*" , ATTRS{model}=="VMware Virtual S", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'"
+-
++ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*" , ATTRS{model}=="Virtual disk*", ATTR{timeout}="180"
++ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*" , ATTRS{model}=="VMware Virtual S", ATTR{timeout}="180"

--- a/debian/patches/debian/scsi-udev-rule
+++ b/debian/patches/debian/scsi-udev-rule
@@ -4,5 +4,5 @@
 -ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*" , ATTRS{model}=="Virtual disk*", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'"
 -ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*" , ATTRS{model}=="VMware Virtual S", RUN+="/bin/sh -c 'echo 180 >/sys$DEVPATH/device/timeout'"
 -
-+ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*" , ATTRS{model}=="Virtual disk*", ATTR{timeout}="180"
-+ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{vendor}=="VMware*" , ATTRS{model}=="VMware Virtual S", ATTR{timeout}="180"
++ACTION=="add", SUBSYSTEMS=="scsi", ENV{DEVTYPE}=="scsi_device", ATTRS{vendor}=="VMware*" , ATTRS{model}=="Virtual disk*", ATTR{timeout}="180"
++ACTION=="add", SUBSYSTEMS=="scsi", ENV{DEVTYPE}=="scsi_device", ATTRS{vendor}=="VMware*" , ATTRS{model}=="VMware Virtual S", ATTR{timeout}="180"

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,4 @@ from_arch/0001-Fix-vmxnet-module-on-kernels-3.16.patch
 debian/enable_vmhgfs-fuse_by_default
 debian/vmxnet_fix_kernel_4.7.patch
 debian/cve-2015-5191.patch
+debian/scsi-udev-rule


### PR DESCRIPTION
This issue was added on vmware/open-vm-tools#183.
Applying patch and restart VM, timeout parameter is set correctly.
```
# sda
$ cat /sys/devices/pci0000:00/0000:00:10.0/host0/target0:0:0/0:0:0:0/timeout
180
# cdrom
$ cat /sys/devices/pci0000:00/0000:00:07.1/ata1/host1/target1:0:0/1:0:0:0/timeout
30
```
