### PR TITLE
d/rules: drop workarounds for run-vmblock

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -125,14 +125,6 @@ override_dh_systemd_start:
 	dh_systemd_start -popen-vm-tools
 	dh_systemd_start -popen-vm-tools --name vgauth
 	dh_systemd_start -popen-vm-tools-desktop -r --no-restart-after-upgrade run-vmblock\\x2dfuse.mount
-	sed -i 's,run-vmblock\\x2dfuse,run-vmblock\\\\x2dfuse,g' debian/*.debhelper
-	sed -i 's,run-vmblock-fuse,run-vmblock\\\\x2dfuse,g' debian/*.debhelper
 
 override_dh_installchangelogs:
 	dh_installchangelogs ReleaseNotes.md
-
-override_dh_md5sums-arch:
-	dh_md5sums
-	# remove broken \ escaping from md5sums
-	sed -i -e 's,^\\,,' -e 's,\\\\,\\,' debian/open-vm-tools-desktop/DEBIAN/md5sums
-


### PR DESCRIPTION
In debhelper 11 the names of the run-vmblock files are handled
correctly. In fact our old fixes now break it and cause the old issue.
So drop the fixes for Debian-sid.

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>