### PR TITLE
Ensure vmwgfx module is loaded before start of vmtoolsd

### DIFF
--- a/debian/desktop.conf
+++ b/debian/desktop.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=-/sbin/modprobe vmwgfx

--- a/debian/rules
+++ b/debian/rules
@@ -66,6 +66,9 @@ override_dh_auto_install:
 	mkdir -p debian/open-vm-tools-desktop/etc/xdg/autostart
 	mv debian/open-vm-tools/etc/xdg/autostart/vmware-user.desktop debian/open-vm-tools-desktop/etc/xdg/autostart
 	rm -rf debian/open-vm-tools/etc/xdg
+	
+	mkdir -p debian/open-vm-tools-desktop/lib/systemd/system/open-vm-tools.service.d
+	cp debian/desktop.conf debian/open-vm-tools-desktop/lib/systemd/system/open-vm-tools.service.d/
 
 override_dh_builddeb:
 	dh_builddeb -- -Zxz


### PR DESCRIPTION
This avoids a failure to start the resolutionKMS plugin and it's
achieved through a drop-in snippet extending open-vm-tools.service
adding an ExecStartPre directive loading the module prior to
the start of the service.

Closes: #915031