### PR TITLE
d/rules: fix dangling symlink of vmware-user

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Architecture: amd64 i386
 Depends: ${misc:Depends}, ${shlibs:Depends}, pciutils, iproute2
 Recommends: ethtool, zerofree, fuse, lsb-release
 Suggests: open-vm-tools-desktop, cloud-init
-Breaks: open-vm-tools-desktop (<< 2:10.0.7-3227872-2~)
+Breaks: open-vm-tools-desktop (<< 2:10.3.5-1~)
 Replaces: open-vm-tools-desktop (<< 2:10.0.7-3227872-2~)
 Description: Open VMware Tools for virtual machines hosted on VMware (CLI)
  The Open Virtual Machine Tools (open-vm-tools) project is an open source
@@ -37,8 +37,8 @@ Architecture: amd64 i386
 Depends: ${misc:Depends}, ${shlibs:Depends},
  open-vm-tools (= ${binary:Version}),
  fuse
-Breaks: open-vm-tools (<< 2:10.0.0~)
-Replaces: open-vm-tools (<< 2:10.0.0~)
+Breaks: open-vm-tools (<< 2:10.3.5-1~)
+Replaces: open-vm-tools (<< 2:10.3.5-1~)
 Recommends:
  xauth, xserver-xorg-input-vmmouse,
  xserver-xorg-video-vmware

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Architecture: amd64 i386
 Depends: ${misc:Depends}, ${shlibs:Depends}, pciutils, iproute2
 Recommends: ethtool, zerofree, fuse, lsb-release
 Suggests: open-vm-tools-desktop, cloud-init
-Breaks: open-vm-tools-desktop (<< 2:10.3.5-1~)
+Breaks: open-vm-tools-desktop (<< 2:10.3.5-2~)
 Replaces: open-vm-tools-desktop (<< 2:10.0.7-3227872-2~)
 Description: Open VMware Tools for virtual machines hosted on VMware (CLI)
  The Open Virtual Machine Tools (open-vm-tools) project is an open source
@@ -37,8 +37,8 @@ Architecture: amd64 i386
 Depends: ${misc:Depends}, ${shlibs:Depends},
  open-vm-tools (= ${binary:Version}),
  fuse
-Breaks: open-vm-tools (<< 2:10.3.5-1~)
-Replaces: open-vm-tools (<< 2:10.3.5-1~)
+Breaks: open-vm-tools (<< 2:10.3.5-2~)
+Replaces: open-vm-tools (<< 2:10.3.5-2~)
 Recommends:
  xauth, xserver-xorg-input-vmmouse,
  xserver-xorg-video-vmware

--- a/debian/rules
+++ b/debian/rules
@@ -62,6 +62,7 @@ override_dh_auto_install:
 
 	mkdir -p debian/open-vm-tools-desktop/usr/bin
 	mv debian/open-vm-tools/usr/bin/vmware-user-suid-wrapper debian/open-vm-tools-desktop/usr/bin
+	mv debian/open-vm-tools/usr/bin/vmware-user debian/open-vm-tools-desktop/usr/bin
 
 	mkdir -p debian/open-vm-tools-desktop/etc/xdg/autostart
 	mv debian/open-vm-tools/etc/xdg/autostart/vmware-user.desktop debian/open-vm-tools-desktop/etc/xdg/autostart


### PR DESCRIPTION
Back in 2:9.4.0-1280544-6 vmware-user* was moved to the
open-vm-tools-desktop package and some follow on fixes moved bits that
were forgotten like the man page.

There still is a symlink in /usr/bin/vmware-user that is forgotten in
the base package and broken unless open-vm-tools-desktop is installed.
Change d/rules to move the symlink as well.

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>