### PR TITLE
Start vgauth before vmtoolsd

### DIFF
--- a/debian/open-vm-tools.service
+++ b/debian/open-vm-tools.service
@@ -4,6 +4,7 @@ Documentation=http://open-vm-tools.sourceforge.net/about.php
 ConditionVirtualization=vmware
 DefaultDependencies=no
 Before=cloud-init-local.service
+After=vgauth.service
 RequiresMountsFor=/tmp
 After=systemd-remount-fs.service systemd-tmpfiles-setup.service
 

--- a/debian/open-vm-tools.vgauth.service
+++ b/debian/open-vm-tools.vgauth.service
@@ -2,6 +2,7 @@
 Description=Authentication service for virtual machines hosted on VMware
 Documentation=http://github.com/vmware/open-vm-tools
 ConditionVirtualization=vmware
+DefaultDependencies=no
 PartOf=open-vm-tools.service
 
 [Service]


### PR DESCRIPTION
VGAuthService needs to be ready when vmtoolsd runs. Certain cases - e.g.
Site Recovery Manager failover - will need vgauth to be up.
Therefore add an After=vgauth.service dependency to open-vm-tools.service

To have vgauth be able start early - and not pull cloud-init back late - it
is also required to drop default dependencies which according to VMware is
fine to do so.

Fixes: https://bugs.launchpad.net/ubuntu/+source/open-vm-tools/+bug/1804287

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>