### PR TITLE
Add modaliases to open-vm-tools-desktop

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -43,6 +43,7 @@ Recommends:
  xauth, xserver-xorg-input-vmmouse,
  xserver-xorg-video-vmware
 Suggests: xdg-utils
+XB-Modaliases: ${modaliases}
 Description: Open VMware Tools for virtual machines hosted on VMware (GUI)
  The Open Virtual Machine Tools (open-vm-tools) project is an open source
  implementation of VMware Tools. It is a suite of virtualization utilities and

--- a/debian/rules
+++ b/debian/rules
@@ -3,6 +3,12 @@
 DEBHELPER_VERSION = $(strip $(shell dpkg-query -f '$${Version}' -W debhelper))
 DEBHELPER_SYSTEMD_OK = $(strip $(shell dpkg --compare-versions $(DEBHELPER_VERSION) ge 10.9.1~; echo $$?))
 
+ifeq ($(shell dpkg-vendor --derives-from Ubuntu && echo yes),yes)
+	VENDOR := UBUNTU
+else
+	VENDOR := DEBIAN
+endif
+
 %:
 	dh ${@} --sourcedirectory=open-vm-tools
 
@@ -71,6 +77,13 @@ override_dh_auto_install:
 	mkdir -p debian/open-vm-tools-desktop/lib/systemd/system/open-vm-tools.service.d
 	cp debian/desktop.conf debian/open-vm-tools-desktop/lib/systemd/system/open-vm-tools.service.d/
 
+override_dh_gencontrol:
+	if [ "${VENDOR}" = "UBUNTU" ]; \
+	then \
+		dh_gencontrol -- -Vmodaliases="vmwgfx(pci:v000015ADd00000405sv*sd*bc*sc*i*)"; \
+	else \
+		dh_gencontrol; \
+	fi
 override_dh_builddeb:
 	dh_builddeb -- -Zxz
 


### PR DESCRIPTION
Added Modaliases to open-vm-tools-desktop to auto-discover and
auto-install the driver on Ubuntu via ubuntu-drivers. The driver is then
installed at installation time and available on first boot for an
improved user experience (LP: #1819207)