### PR TITLE
d/control: fix postinst missing lsmod/modprobe

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -36,7 +36,8 @@ Package: open-vm-tools-desktop
 Architecture: amd64 i386
 Depends: ${misc:Depends}, ${shlibs:Depends},
  open-vm-tools (= ${binary:Version}),
- fuse
+ fuse,
+ kmod,
 Breaks: open-vm-tools (<< 2:10.3.5-2~)
 Replaces: open-vm-tools (<< 2:10.3.5-2~)
 Recommends:


### PR DESCRIPTION
Upgrades on open-vm-desktop can trigger errors like the following:
/var/lib/dpkg/info/open-vm-tools-desktop.postinst: 5:
/var/lib/dpkg/info/open-vm-tools-desktop.postinst: lsmod: not found
/var/lib/dpkg/info/open-vm-tools-desktop.postinst: 6:
/var/lib/dpkg/info/open-vm-tools-desktop.postinst: modprobe: not found

The reason is that kmod isn't a dependency of open-vm-tools-desktop and
could be missing e.g. if you installed it in a system container.
Once might discuss how useful open-vm-tools-desktop is in that
environment but a n issue to fix none the less.

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>